### PR TITLE
Formatted quantised tube data

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,7 +9,6 @@ const dataBlockDuration = 30; // seconds
 function App() {
   const [tubeData, setTubeData] = useState([]);
 
-  let durationPassed = 0; // base time used in Arrivals.js
   const lines = "bakerloo,central,circle,district,hammersmith-city,jubilee,metropolitan,northern,piccadilly,victoria,waterloo-city";
 
   useEffect(() => {
@@ -46,7 +45,7 @@ function App() {
   }, []);
 
   useEffect(() => {  // Display tube data whenever it changes
-    console.log(tubeData);
+    // console.log(tubeData);
   }, [tubeData]);
 
   return (
@@ -54,7 +53,7 @@ function App() {
       <header className="App-header">
         <h2>LUSO</h2>
         <img src={logo} className="App-logo" alt="logo" />
-        <Arrivals tubeData={tubeData} durationPassed={durationPassed} />
+        <Arrivals tubeData={tubeData} />
       </header>
     </div>
   );

--- a/frontend/src/components/Arrivals.js
+++ b/frontend/src/components/Arrivals.js
@@ -1,47 +1,37 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import './Arrivals.css';
 
-const Arrivals = ({ tubeData, durationPassed }) => {
-  const [newArrival, setNewArrival] = useState('');
-  const durationPassedRef = useRef(durationPassed);
-  const timeInterval = 125;
+// below are the combined varibles for transforming timeToStation into sub-second intervals
+// ONLY set the BPM. Do NOT change the other variables.
+const bpm = 60; 
+const noteInterval = 60 / (bpm * 4); // for 1/16th note in seconds
+const randomIntervalMultiplier = 1 / noteInterval;
+
+const Arrivals = ({ tubeData }) => {
   
   useEffect(() => {
-    
-    const scheduleTrains = () => {
-      const trainData = tubeData;
-      const arrivingNext = [];
-      if (trainData.length > 0) { 
-        if (durationPassedRef.current > trainData[0].timeToStation) {
-          // setNewArrival(trainData[0].stationName);
-          arrivingNext.push(trainData.shift());
-          // if a train has been added to arrivingNext...
-          while (trainData.length > 0 && !arrivingNext.some(obj => obj.lineName === trainData[0].lineName) && durationPassedRef.current > trainData[0].timeToStation) {
-            // setNewArrival(trainData[0].stationName);
-            arrivingNext.push(trainData.shift());
-          }
-        }
-      }
-      // console.log(arrivingNext);
-      durationPassedRef.current += (timeInterval / 1000);
-      
-      arrivingNext.forEach(train => {
-        console.log(`${train.lineName} : ${train.stationName}`)
-        setNewArrival(train.stationName);
-      });
-      console.log('-')
-    };
-
-    // run scheduleTrains every 150ms
-    const sixteenthInterval = setInterval(scheduleTrains, timeInterval);
-
-    // Clean up the interval on component unmount
-    return () => clearInterval(sixteenthInterval);
+    if (tubeData.length > 0) {
+    addIntervals();
+    }
   }, [tubeData]);
+
+  const addIntervals = () => {
+    const quantisedData = tubeData.map((train) => {
+      const randomInterval = (Math.floor(Math.random() * randomIntervalMultiplier))/randomIntervalMultiplier;
+      // console.log(randomInterval)
+      return {
+        ...train,
+        timeToStation: train.timeToStation + randomInterval
+      };
+    });
+    console.log(quantisedData);
+    // save quantisedData to localStorage
+    localStorage.setItem('quantisedData', JSON.stringify(quantisedData, null, 2));
+    return quantisedData;
+  };
 
   return (
     <div>
-      <p cy-data='arrival-info'>{tubeData.length > 0 && newArrival}</p>
     </div>
   );
 };

--- a/sampleData/quantisedSample1.json
+++ b/sampleData/quantisedSample1.json
@@ -1,0 +1,554 @@
+[
+  {
+    "id": "-1372524375",
+    "stationName": "Bounds Green Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 10.25
+  },
+  {
+    "id": "-1867591545",
+    "stationName": "Knightsbridge Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 10
+  },
+  {
+    "id": "350863924",
+    "stationName": "Caledonian Road Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 10.5
+  },
+  {
+    "id": "-108250550",
+    "stationName": "Piccadilly Circus Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 10.5
+  },
+  {
+    "id": "-163420404",
+    "stationName": "Finsbury Park Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 10.75
+  },
+  {
+    "id": "-1354575267",
+    "stationName": "Hounslow West Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 10
+  },
+  {
+    "id": "217801728",
+    "stationName": "Gloucester Road Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 11.25
+  },
+  {
+    "id": "-556021977",
+    "stationName": "Turnpike Lane Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 11.75
+  },
+  {
+    "id": "-1510904958",
+    "stationName": "Wood Green Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 11.5
+  },
+  {
+    "id": "-1435087620",
+    "stationName": "Clapham South Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 16.25
+  },
+  {
+    "id": "991214922",
+    "stationName": "Tooting Bec Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 16.5
+  },
+  {
+    "id": "-1028858544",
+    "stationName": "South Wimbledon Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 16
+  },
+  {
+    "id": "-2054970242",
+    "stationName": "Oval Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 16.75
+  },
+  {
+    "id": "1955894769",
+    "stationName": "Old Street Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 16.5
+  },
+  {
+    "id": "-1639249153",
+    "stationName": "Elephant & Castle Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 16
+  },
+  {
+    "id": "-834620664",
+    "stationName": "Hendon Central Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 16.25
+  },
+  {
+    "id": "1394480056",
+    "stationName": "Tooting Bec Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 16.75
+  },
+  {
+    "id": "885040115",
+    "stationName": "West Finchley Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 17.5
+  },
+  {
+    "id": "-528407612",
+    "stationName": "Charing Cross Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 17
+  },
+  {
+    "id": "-1410323860",
+    "stationName": "Moorgate Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 17.25
+  },
+  {
+    "id": "-1176994785",
+    "stationName": "Belsize Park Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 17
+  },
+  {
+    "id": "834314010",
+    "stationName": "Embankment Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 17
+  },
+  {
+    "id": "1966207842",
+    "stationName": "Highgate Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 17
+  },
+  {
+    "id": "-1208655092",
+    "stationName": "Gloucester Road Underground Station",
+    "lineName": "Circle",
+    "timeToStation": 22.25
+  },
+  {
+    "id": "2056633330",
+    "stationName": "Bayswater Underground Station",
+    "lineName": "Hammersmith & City",
+    "timeToStation": 22
+  },
+  {
+    "id": "-1655187398",
+    "stationName": "Aldgate Underground Station",
+    "lineName": "Circle",
+    "timeToStation": 23
+  },
+  {
+    "id": "110413654",
+    "stationName": "St. James's Park Underground Station",
+    "lineName": "Circle",
+    "timeToStation": 23.25
+  },
+  {
+    "id": "-767125939",
+    "stationName": "Monument Underground Station",
+    "lineName": "Circle",
+    "timeToStation": 23.25
+  },
+  {
+    "id": "-1790543580",
+    "stationName": "Goldhawk Road Underground Station",
+    "lineName": "Hammersmith & City",
+    "timeToStation": 23.5
+  },
+  {
+    "id": "1476812000",
+    "stationName": "Shepherd's Bush Market Underground Station",
+    "lineName": "Hammersmith & City",
+    "timeToStation": 23.75
+  },
+  {
+    "id": "-359453507",
+    "stationName": "Edgware Road (Circle Line) Underground Station",
+    "lineName": "Hammersmith & City",
+    "timeToStation": 23.5
+  },
+  {
+    "id": "85150429",
+    "stationName": "Bank Underground Station",
+    "lineName": "Waterloo & City",
+    "timeToStation": 26.25
+  },
+  {
+    "id": "85150429",
+    "stationName": "Bank Underground Station",
+    "lineName": "Waterloo & City",
+    "timeToStation": 26
+  },
+  {
+    "id": "-809217610",
+    "stationName": "Waterloo Underground Station",
+    "lineName": "Waterloo & City",
+    "timeToStation": 26
+  },
+  {
+    "id": "-1377923202",
+    "stationName": "Willesden Junction Underground Station",
+    "lineName": "Bakerloo",
+    "timeToStation": 27.5
+  },
+  {
+    "id": "408022896",
+    "stationName": "Bond Street Underground Station",
+    "lineName": "Central",
+    "timeToStation": 27.5
+  },
+  {
+    "id": "1144268066",
+    "stationName": "Liverpool Street Underground Station",
+    "lineName": "Central",
+    "timeToStation": 27.75
+  },
+  {
+    "id": "-1877275544",
+    "stationName": "Newbury Park Underground Station",
+    "lineName": "Central",
+    "timeToStation": 27.75
+  },
+  {
+    "id": "853052730",
+    "stationName": "Woodford Underground Station",
+    "lineName": "Central",
+    "timeToStation": 27.75
+  },
+  {
+    "id": "-1670737428",
+    "stationName": "Chancery Lane Underground Station",
+    "lineName": "Central",
+    "timeToStation": 27.5
+  },
+  {
+    "id": "-200805883",
+    "stationName": "Woodford Underground Station",
+    "lineName": "Central",
+    "timeToStation": 27
+  },
+  {
+    "id": "1727110119",
+    "stationName": "Wimbledon Underground Station",
+    "lineName": "District",
+    "timeToStation": 27.75
+  },
+  {
+    "id": "-584332277",
+    "stationName": "Hornchurch Underground Station",
+    "lineName": "District",
+    "timeToStation": 27.5
+  },
+  {
+    "id": "-2006107237",
+    "stationName": "Elm Park Underground Station",
+    "lineName": "District",
+    "timeToStation": 27.25
+  },
+  {
+    "id": "989427540",
+    "stationName": "Edgware Road (Circle Line) Underground Station",
+    "lineName": "District",
+    "timeToStation": 27.5
+  },
+  {
+    "id": "1727110119",
+    "stationName": "Wimbledon Underground Station",
+    "lineName": "District",
+    "timeToStation": 27.25
+  },
+  {
+    "id": "1722770156",
+    "stationName": "Kew Gardens Underground Station",
+    "lineName": "District",
+    "timeToStation": 27
+  },
+  {
+    "id": "-1684028817",
+    "stationName": "Upney Underground Station",
+    "lineName": "District",
+    "timeToStation": 27.5
+  },
+  {
+    "id": "1727110119",
+    "stationName": "Wimbledon Underground Station",
+    "lineName": "District",
+    "timeToStation": 27.75
+  },
+  {
+    "id": "1727110119",
+    "stationName": "Wimbledon Underground Station",
+    "lineName": "District",
+    "timeToStation": 27
+  },
+  {
+    "id": "1457137523",
+    "stationName": "Barking Underground Station",
+    "lineName": "District",
+    "timeToStation": 27.75
+  },
+  {
+    "id": "466400058",
+    "stationName": "Mansion House Underground Station",
+    "lineName": "District",
+    "timeToStation": 27.25
+  },
+  {
+    "id": "1079388532",
+    "stationName": "Aldgate East Underground Station",
+    "lineName": "District",
+    "timeToStation": 27
+  },
+  {
+    "id": "-1684553192",
+    "stationName": "Fulham Broadway Underground Station",
+    "lineName": "District",
+    "timeToStation": 27.5
+  },
+  {
+    "id": "-873723992",
+    "stationName": "Liverpool Street Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 27.25
+  },
+  {
+    "id": "933248764",
+    "stationName": "Barbican Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 27.75
+  },
+  {
+    "id": "-746348427",
+    "stationName": "Rickmansworth Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 27.75
+  },
+  {
+    "id": "1683192942",
+    "stationName": "Wembley Park Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 27.75
+  },
+  {
+    "id": "1315825078",
+    "stationName": "Seven Sisters Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 27
+  },
+  {
+    "id": "-1193744498",
+    "stationName": "Green Park Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 27
+  },
+  {
+    "id": "1368475801",
+    "stationName": "Walthamstow Central Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 27.5
+  },
+  {
+    "id": "1919262866",
+    "stationName": "Warren Street Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 27.25
+  },
+  {
+    "id": "-418414724",
+    "stationName": "Highbury & Islington Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 27
+  },
+  {
+    "id": "-861018032",
+    "stationName": "Victoria Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 27.75
+  },
+  {
+    "id": "727386832",
+    "stationName": "Stonebridge Park Underground Station",
+    "lineName": "Bakerloo",
+    "timeToStation": 28.25
+  },
+  {
+    "id": "1833410840",
+    "stationName": "White City Underground Station",
+    "lineName": "Central",
+    "timeToStation": 28.75
+  },
+  {
+    "id": "-533286795",
+    "stationName": "Leytonstone Underground Station",
+    "lineName": "Central",
+    "timeToStation": 28.75
+  },
+  {
+    "id": "-1008906523",
+    "stationName": "Holborn Underground Station",
+    "lineName": "Central",
+    "timeToStation": 28
+  },
+  {
+    "id": "-2060174628",
+    "stationName": "Buckhurst Hill Underground Station",
+    "lineName": "Central",
+    "timeToStation": 28.25
+  },
+  {
+    "id": "-1604011393",
+    "stationName": "Holborn Underground Station",
+    "lineName": "Central",
+    "timeToStation": 28.5
+  },
+  {
+    "id": "-935974209",
+    "stationName": "Queensway Underground Station",
+    "lineName": "Central",
+    "timeToStation": 28.75
+  },
+  {
+    "id": "756372503",
+    "stationName": "Bethnal Green Underground Station",
+    "lineName": "Central",
+    "timeToStation": 28.5
+  },
+  {
+    "id": "-1071395363",
+    "stationName": "Parsons Green Underground Station",
+    "lineName": "Circle",
+    "timeToStation": 28.75
+  },
+  {
+    "id": "-49066944",
+    "stationName": "Embankment Underground Station",
+    "lineName": "District",
+    "timeToStation": 28.25
+  },
+  {
+    "id": "-2047940058",
+    "stationName": "Green Park Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 28.75
+  },
+  {
+    "id": "-1847905876",
+    "stationName": "Finchley Road Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 28
+  },
+  {
+    "id": "1438984795",
+    "stationName": "Bond Street Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 28.5
+  },
+  {
+    "id": "-1735052525",
+    "stationName": "London Bridge Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 28
+  },
+  {
+    "id": "-334816611",
+    "stationName": "Canning Town Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 28.75
+  },
+  {
+    "id": "-380968763",
+    "stationName": "Ruislip Manor Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 28.5
+  },
+  {
+    "id": "1744869812",
+    "stationName": "Chalfont & Latimer Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 28.25
+  },
+  {
+    "id": "-763146259",
+    "stationName": "Northwick Park Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 28
+  },
+  {
+    "id": "1048927843",
+    "stationName": "North Harrow Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 28.75
+  },
+  {
+    "id": "131565766",
+    "stationName": "Ruislip Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 28.25
+  },
+  {
+    "id": "-944211628",
+    "stationName": "Harrow-on-the-Hill Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 28.75
+  },
+  {
+    "id": "-944211628",
+    "stationName": "Harrow-on-the-Hill Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 28.25
+  },
+  {
+    "id": "-796445243",
+    "stationName": "Euston Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 28
+  },
+  {
+    "id": "966780527",
+    "stationName": "Vauxhall Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 28
+  },
+  {
+    "id": "-9708239",
+    "stationName": "Vauxhall Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 28.25
+  },
+  {
+    "id": "-167861996",
+    "stationName": "Kilburn Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 29.75
+  },
+  {
+    "id": "-1734986989",
+    "stationName": "London Bridge Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 29.5
+  },
+  {
+    "id": "1351495095",
+    "stationName": "West Ham Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 29.5
+  }
+]

--- a/sampleData/quantisedSample2.json
+++ b/sampleData/quantisedSample2.json
@@ -1,0 +1,464 @@
+[
+  {
+    "id": "-1735314671",
+    "stationName": "Bond Street Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 8.5
+  },
+  {
+    "id": "-173629615",
+    "stationName": "Bermondsey Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 9.75
+  },
+  {
+    "id": "-1063969422",
+    "stationName": "Marylebone Underground Station",
+    "lineName": "Bakerloo",
+    "timeToStation": 11
+  },
+  {
+    "id": "2023245889",
+    "stationName": "Kenton Underground Station",
+    "lineName": "Bakerloo",
+    "timeToStation": 11.75
+  },
+  {
+    "id": "-486945381",
+    "stationName": "Marble Arch Underground Station",
+    "lineName": "Central",
+    "timeToStation": 11.75
+  },
+  {
+    "id": "964038168",
+    "stationName": "Hanger Lane Underground Station",
+    "lineName": "Central",
+    "timeToStation": 11.75
+  },
+  {
+    "id": "285535694",
+    "stationName": "Tottenham Court Road Underground Station",
+    "lineName": "Central",
+    "timeToStation": 11
+  },
+  {
+    "id": "889686586",
+    "stationName": "Notting Hill Gate Underground Station",
+    "lineName": "Central",
+    "timeToStation": 11
+  },
+  {
+    "id": "1751688129",
+    "stationName": "Wanstead Underground Station",
+    "lineName": "Central",
+    "timeToStation": 11.75
+  },
+  {
+    "id": "1162222433",
+    "stationName": "Upney Underground Station",
+    "lineName": "District",
+    "timeToStation": 11.25
+  },
+  {
+    "id": "-128562281",
+    "stationName": "Ealing Common Underground Station",
+    "lineName": "District",
+    "timeToStation": 11.25
+  },
+  {
+    "id": "1814732465",
+    "stationName": "Plaistow Underground Station",
+    "lineName": "District",
+    "timeToStation": 11.5
+  },
+  {
+    "id": "676694865",
+    "stationName": "Stamford Brook Underground Station",
+    "lineName": "District",
+    "timeToStation": 11
+  },
+  {
+    "id": "-1438669744",
+    "stationName": "Sloane Square Underground Station",
+    "lineName": "District",
+    "timeToStation": 11.25
+  },
+  {
+    "id": "1587140362",
+    "stationName": "King's Cross St. Pancras Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 11.25
+  },
+  {
+    "id": "-896704201",
+    "stationName": "Great Portland Street Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 11
+  },
+  {
+    "id": "567830933",
+    "stationName": "Warren Street Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 11
+  },
+  {
+    "id": "966911599",
+    "stationName": "Vauxhall Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 11.25
+  },
+  {
+    "id": "294586456",
+    "stationName": "Pimlico Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 11.5
+  },
+  {
+    "id": "-1575906849",
+    "stationName": "Oxford Circus Underground Station",
+    "lineName": "Bakerloo",
+    "timeToStation": 12.25
+  },
+  {
+    "id": "1956391839",
+    "stationName": "Waterloo Underground Station",
+    "lineName": "Bakerloo",
+    "timeToStation": 12.5
+  },
+  {
+    "id": "531361645",
+    "stationName": "Mile End Underground Station",
+    "lineName": "Central",
+    "timeToStation": 12
+  },
+  {
+    "id": "1520544438",
+    "stationName": "Chancery Lane Underground Station",
+    "lineName": "Central",
+    "timeToStation": 12
+  },
+  {
+    "id": "-935449909",
+    "stationName": "Ealing Broadway Underground Station",
+    "lineName": "Central",
+    "timeToStation": 12.75
+  },
+  {
+    "id": "408022911",
+    "stationName": "Snaresbrook Underground Station",
+    "lineName": "Central",
+    "timeToStation": 12.75
+  },
+  {
+    "id": "-1883318077",
+    "stationName": "South Woodford Underground Station",
+    "lineName": "Central",
+    "timeToStation": 12.5
+  },
+  {
+    "id": "1216291720",
+    "stationName": "Gants Hill Underground Station",
+    "lineName": "Central",
+    "timeToStation": 12
+  },
+  {
+    "id": "759195050",
+    "stationName": "Fairlop Underground Station",
+    "lineName": "Central",
+    "timeToStation": 12.75
+  },
+  {
+    "id": "1452858892",
+    "stationName": "Upminster Underground Station",
+    "lineName": "District",
+    "timeToStation": 12.25
+  },
+  {
+    "id": "-1282793226",
+    "stationName": "South Kensington Underground Station",
+    "lineName": "District",
+    "timeToStation": 12.5
+  },
+  {
+    "id": "85913118",
+    "stationName": "Turnham Green Underground Station",
+    "lineName": "District",
+    "timeToStation": 12.25
+  },
+  {
+    "id": "-444779134",
+    "stationName": "Goldhawk Road Underground Station",
+    "lineName": "Hammersmith & City",
+    "timeToStation": 12.25
+  },
+  {
+    "id": "1000795289",
+    "stationName": "Upton Park Underground Station",
+    "lineName": "Hammersmith & City",
+    "timeToStation": 12.25
+  },
+  {
+    "id": "1651333592",
+    "stationName": "Moorgate Underground Station",
+    "lineName": "Hammersmith & City",
+    "timeToStation": 12
+  },
+  {
+    "id": "726663749",
+    "stationName": "Queensbury Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 12
+  },
+  {
+    "id": "1803190923",
+    "stationName": "West Hampstead Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 12.75
+  },
+  {
+    "id": "-1646915604",
+    "stationName": "Neasden Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 12
+  },
+  {
+    "id": "1689677798",
+    "stationName": "Swiss Cottage Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 12
+  },
+  {
+    "id": "2062618778",
+    "stationName": "Harrow-on-the-Hill Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 12
+  },
+  {
+    "id": "2062618778",
+    "stationName": "Harrow-on-the-Hill Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 12.25
+  },
+  {
+    "id": "862826827",
+    "stationName": "Tottenham Hale Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 12.75
+  },
+  {
+    "id": "1885553026",
+    "stationName": "Bond Street Underground Station",
+    "lineName": "Central",
+    "timeToStation": 13.25
+  },
+  {
+    "id": "-1817707069",
+    "stationName": "Westminster Underground Station",
+    "lineName": "Circle",
+    "timeToStation": 13.75
+  },
+  {
+    "id": "-1468443907",
+    "stationName": "Westbourne Park Underground Station",
+    "lineName": "Circle",
+    "timeToStation": 13.75
+  },
+  {
+    "id": "-1951441936",
+    "stationName": "Westminster Underground Station",
+    "lineName": "Circle",
+    "timeToStation": 13.25
+  },
+  {
+    "id": "1607852243",
+    "stationName": "King's Cross St. Pancras Underground Station",
+    "lineName": "Circle",
+    "timeToStation": 13.25
+  },
+  {
+    "id": "-47890303",
+    "stationName": "Aldgate East Underground Station",
+    "lineName": "District",
+    "timeToStation": 13
+  },
+  {
+    "id": "675090502",
+    "stationName": "Shepherd's Bush Market Underground Station",
+    "lineName": "Hammersmith & City",
+    "timeToStation": 13.25
+  },
+  {
+    "id": "713496499",
+    "stationName": "Mile End Underground Station",
+    "lineName": "Hammersmith & City",
+    "timeToStation": 13.75
+  },
+  {
+    "id": "1528219493",
+    "stationName": "West Hampstead Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 13.5
+  },
+  {
+    "id": "-2048398710",
+    "stationName": "Stanmore Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 13.25
+  },
+  {
+    "id": "-1884229675",
+    "stationName": "North Greenwich Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 13.25
+  },
+  {
+    "id": "100329091",
+    "stationName": "Dollis Hill Underground Station",
+    "lineName": "Jubilee",
+    "timeToStation": 13.75
+  },
+  {
+    "id": "799727757",
+    "stationName": "Barbican Underground Station",
+    "lineName": "Metropolitan",
+    "timeToStation": 13.75
+  },
+  {
+    "id": "-613412055",
+    "stationName": "Green Park Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 13.25
+  },
+  {
+    "id": "-1655187398",
+    "stationName": "Aldgate Underground Station",
+    "lineName": "Circle",
+    "timeToStation": 14.25
+  },
+  {
+    "id": "-1655187398",
+    "stationName": "Aldgate Underground Station",
+    "lineName": "Circle",
+    "timeToStation": 14.25
+  },
+  {
+    "id": "-602519484",
+    "stationName": "Blackfriars Underground Station",
+    "lineName": "District",
+    "timeToStation": 14.5
+  },
+  {
+    "id": "1814142812",
+    "stationName": "Cannon Street Underground Station",
+    "lineName": "District",
+    "timeToStation": 14.5
+  },
+  {
+    "id": "-1016672936",
+    "stationName": "Green Park Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 14.25
+  },
+  {
+    "id": "1715108578",
+    "stationName": "Finsbury Park Underground Station",
+    "lineName": "Victoria",
+    "timeToStation": 14.25
+  },
+  {
+    "id": "1467749435",
+    "stationName": "Balham Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 16.75
+  },
+  {
+    "id": "-567659288",
+    "stationName": "Alperton Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 16.75
+  },
+  {
+    "id": "1576585692",
+    "stationName": "Hammersmith (Dist&Picc Line) Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 24.5
+  },
+  {
+    "id": "-1914686055",
+    "stationName": "Green Park Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 24.75
+  },
+  {
+    "id": "-1212976072",
+    "stationName": "Russell Square Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 24.25
+  },
+  {
+    "id": "1907183414",
+    "stationName": "Hounslow West Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 24.5
+  },
+  {
+    "id": "-2046487689",
+    "stationName": "Cockfosters Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 25.75
+  },
+  {
+    "id": "376696387",
+    "stationName": "Eastcote Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 25.75
+  },
+  {
+    "id": "-295976643",
+    "stationName": "Green Park Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 25.75
+  },
+  {
+    "id": "-2021911688",
+    "stationName": "King's Cross St. Pancras Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 25
+  },
+  {
+    "id": "-565524700",
+    "stationName": "Holborn Underground Station",
+    "lineName": "Piccadilly",
+    "timeToStation": 25.25
+  },
+  {
+    "id": "990494043",
+    "stationName": "Finchley Central Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 29.75
+  },
+  {
+    "id": "-436592587",
+    "stationName": "Elephant & Castle Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 29.25
+  },
+  {
+    "id": "-909852657",
+    "stationName": "Euston Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 29.75
+  },
+  {
+    "id": "1533097102",
+    "stationName": "Waterloo Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 29.75
+  },
+  {
+    "id": "78321110",
+    "stationName": "Belsize Park Underground Station",
+    "lineName": "Northern",
+    "timeToStation": 29.75
+  }
+]


### PR DESCRIPTION
Data is altered to be randomly quantised from it original tts.
The intervals are set at the top of the Arrivals.js with the bpm variable.
bpm is currently 60 which means intervals of 250ms.

quantisedData is currently logged, saved to local storage and returned.
Although it is in Arrivals, the Arrival component may now be redundant.